### PR TITLE
Figlet Bug Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ clear();
 console.log(
 	chalk.cyan(
 		figlet.textSync("caddy", {
-			font: "chunky",
+			font: "Chunky",
 		})
 	)
 );


### PR DESCRIPTION
``Error: ENOENT: no such file or directory, open '/home/Desktop/caddy/node_modules/figlet/fonts/chunky.flf'``
It's a figlet internal error, probably because of casing.

Replaced ``chunky`` with ``Chunky``.

kthxbye